### PR TITLE
Upgrade network module to use tf 0.14

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -1,6 +1,6 @@
 module "network" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.44.0"
+  version = "3.1.0"
 
   name = local.resource_name
 


### PR DESCRIPTION
The previous module had a terraform core constraint <0.14.
This fixes that.