### PR TITLE
C808 compliance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Run Bridgecrew
+        id: Bridgecrew
+        uses: bridgecrewio/bridgecrew-action@master
+        with:
+          api-key: ${{ secrets.BC_API_KEY }}
+
       - name: Find version
         id: version
         run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Package files into tgz
       - name: Package
-        run: tar -cvzf module.tgz *.tf
+        run: tar -cvzf module.tgz *.tf vpc/*.tf
 
       # Publish to nullstone
       - name: Publish

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 *.tfvars
 envs/
 __backend__.tf
+.terraform.lock.hcl
 .nullstone/active-workspace.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# block-aws-network
+# aws-network
 
-Nullstone Block standing up an AWS network configured with IPv6 enabled, and public, private, and intra subnets across 3 AZs.
+Nullstone module to create an AWS network configured with IPv6 enabled, and public, private, and intra subnets across 3 AZs.
+
+## Security & Compliance
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+[![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=INFRASTRUCTURE+SECURITY)
+[![CIS AWS V1.3](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/cis_aws_13)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=CIS+AWS+V1.3)
+[![PCI-DSS V3.2](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=PCI-DSS+V3.2)
+[![NIST-800-53](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=NIST-800-53)
+[![ISO27001](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=ISO27001)
+[![SOC2](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=SOC2)
+[![HIPAA](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=HIPAA)
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 [![SOC2](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=SOC2)
 [![HIPAA](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-network/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-network&benchmark=HIPAA)
 
+#### Notes on Security
+
+This module skips the compliance check for VPC Flow Logs.
+This is done because VPC Flow Logs greatly increase your AWS bill as your volume of network traffic increases.
+If you require this compliance, add a supplemental Nullstone block to enable VPC Flow Logs.
+
 ## Inputs
 
 - `cidr: string`

--- a/network.tf
+++ b/network.tf
@@ -1,6 +1,5 @@
 module "network" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "3.1.0"
+  source = "./vpc"
 
   name = local.resource_name
   tags = local.tags

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,7 +1,8 @@
 resource "aws_security_group" "vpc_endpoints" {
-  name   = "vpc-endpoints/${local.resource_name}"
-  vpc_id = module.network.vpc_id
-  tags   = local.tags
+  name        = "vpc-endpoints/${local.resource_name}"
+  vpc_id      = module.network.vpc_id
+  tags        = local.tags
+  description = "Security group attached to every VPC endpoint"
 }
 
 resource "aws_security_group_rule" "allow_inside" {
@@ -11,6 +12,7 @@ resource "aws_security_group_rule" "allow_inside" {
   from_port         = 0
   to_port           = 65535
   cidr_blocks       = [var.cidr]
+  description       = "Enable VPC endpoints to access any port for any device on the network"
 }
 
 data "aws_vpc_endpoint_service" "ecr_api" {

--- a/vpc/igw.tf
+++ b/vpc/igw.tf
@@ -18,7 +18,7 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_egress_only_internet_gateway" "this" {
-  count = var.enable_ipv6
+  count = var.enable_ipv6 ? 1 : 0
 
   vpc_id = aws_vpc.this[0].id
   tags   = merge({ "Name" = format("%s", var.name) }, var.tags)

--- a/vpc/igw.tf
+++ b/vpc/igw.tf
@@ -1,0 +1,33 @@
+resource "aws_internet_gateway" "this" {
+  count = length(var.public_subnets) > 0 ? 1 : 0
+
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge({ "Name" = format("%s", var.name) }, var.tags)
+}
+
+resource "aws_route" "public_internet_gateway" {
+  count = length(var.public_subnets) > 0 ? 1 : 0
+
+  route_table_id         = aws_route_table.public[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this[0].id
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "this" {
+  count = var.enable_ipv6
+
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge({ "Name" = format("%s", var.name) }, var.tags)
+}
+
+resource "aws_route" "public_internet_gateway_ipv6" {
+  count = var.enable_ipv6 && length(var.public_subnets) > 0 ? 1 : 0
+
+  route_table_id              = aws_route_table.public[0].id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.this[0].id
+}

--- a/vpc/intra.tf
+++ b/vpc/intra.tf
@@ -1,0 +1,23 @@
+resource "aws_subnet" "intra" {
+  count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
+
+  vpc_id                          = aws_vpc.this[0].id
+  cidr_block                      = var.intra_subnets[count.index]
+  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+  assign_ipv6_address_on_creation = false
+  tags                            = merge({ "Name" = format("%s-intra-%s", var.name, element(var.azs, count.index)) }, var.tags)
+}
+
+resource "aws_route_table" "intra" {
+  count = length(var.intra_subnets) > 0 ? 1 : 0
+
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge({ "Name" = "${var.name}-intra" }, var.tags)
+}
+
+resource "aws_route_table_association" "intra" {
+  count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
+
+  subnet_id      = element(aws_subnet.intra.*.id, count.index)
+  route_table_id = element(aws_route_table.intra.*.id, 0)
+}

--- a/vpc/nat.tf
+++ b/vpc/nat.tf
@@ -1,0 +1,39 @@
+locals {
+  nat_gateway_count = var.single_nat_gateway ? 1 : length(var.private_subnets)
+}
+
+resource "aws_eip" "nat" {
+  count = var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+  vpc  = true
+  tags = merge({ "Name" = format("%s-%s", var.name, element(var.azs, var.single_nat_gateway ? 0 : count.index)) }, var.tags)
+}
+
+resource "aws_nat_gateway" "this" {
+  count = var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = element(aws_subnet.public.*.id, var.single_nat_gateway ? 0 : count.index)
+  tags          = merge({ "Name" = format("%s-%s", var.name, element(var.azs, var.single_nat_gateway ? 0 : count.index)) }, var.tags)
+  depends_on    = [aws_internet_gateway.this]
+}
+
+resource "aws_route" "private_nat_gateway" {
+  count = var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+  route_table_id         = element(aws_route_table.private.*.id, count.index)
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = element(aws_nat_gateway.this.*.id, count.index)
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_route" "private_ipv6_egress" {
+  count = var.enable_ipv6 ? length(var.private_subnets) : 0
+
+  route_table_id              = element(aws_route_table.private.*.id, count.index)
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this.*.id, 0)
+}

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -1,0 +1,84 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = try(aws_vpc.this[0].id, "")
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = try(aws_vpc.this[0].cidr_block, "")
+}
+
+output "default_security_group_id" {
+  description = "The ID of the security group created by default on VPC creation"
+  value       = try(aws_vpc.this[0].default_security_group_id, "")
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = concat(aws_vpc.this.*.ipv6_cidr_block, [""])[0]
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = aws_subnet.private.*.id
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of private subnets"
+  value       = aws_subnet.private.*.cidr_block
+}
+
+output "private_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.private.*.ipv6_cidr_block
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = aws_subnet.public.*.id
+}
+
+output "public_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of public subnets"
+  value       = aws_subnet.public.*.cidr_block
+}
+
+output "public_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.public.*.ipv6_cidr_block
+}
+
+output "intra_subnets" {
+  description = "List of IDs of intra subnets"
+  value       = aws_subnet.intra.*.id
+}
+
+output "intra_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of intra subnets"
+  value       = aws_subnet.intra.*.cidr_block
+}
+
+output "intra_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of intra subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.intra.*.ipv6_cidr_block
+}
+
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = aws_eip.nat.*.public_ip
+}
+
+output "natgw_ids" {
+  description = "List of NAT Gateway IDs"
+  value       = aws_nat_gateway.this.*.id
+}
+
+output "igw_id" {
+  description = "The ID of the Internet Gateway"
+  value       = try(aws_internet_gateway.this[0].id, "")
+}
+
+output "egress_only_internet_gateway_id" {
+  description = "The ID of the egress only Internet Gateway"
+  value       = try(aws_egress_only_internet_gateway.this[0].id, "")
+}

--- a/vpc/private.tf
+++ b/vpc/private.tf
@@ -1,0 +1,26 @@
+resource "aws_subnet" "private" {
+  count = length(var.private_subnets)
+
+  vpc_id                          = aws_vpc.this[0].id
+  cidr_block                      = var.private_subnets[count.index]
+  availability_zone               = element(var.azs, count.index)
+  assign_ipv6_address_on_creation = false
+  map_public_ip_on_launch         = false
+  map_customer_owned_ip_on_launch = false
+
+  tags = merge({ "Name" = format("%s-private-%s", var.name, element(var.azs, count.index)) }, var.tags)
+}
+
+resource "aws_route_table" "private" {
+  count = var.single_nat_gateway ? 1 : length(var.private_subnets)
+
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge({ "Name" = var.single_nat_gateway ? "${var.name}-private" : format("%s-private-%s", var.name, element(var.azs, count.index)) }, var.tags)
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
+
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, var.single_nat_gateway ? 0 : count.index)
+}

--- a/vpc/private.tf
+++ b/vpc/private.tf
@@ -6,7 +6,6 @@ resource "aws_subnet" "private" {
   availability_zone               = element(var.azs, count.index)
   assign_ipv6_address_on_creation = false
   map_public_ip_on_launch         = false
-  map_customer_owned_ip_on_launch = false
 
   tags = merge({ "Name" = format("%s-private-%s", var.name, element(var.azs, count.index)) }, var.tags)
 }

--- a/vpc/public.tf
+++ b/vpc/public.tf
@@ -6,7 +6,6 @@ resource "aws_subnet" "public" {
   availability_zone               = element(var.azs, count.index)
   assign_ipv6_address_on_creation = false
   map_public_ip_on_launch         = false
-  map_customer_owned_ip_on_launch = false
 
   tags = merge({ "Name" = format("%s-public-%s", var.name, element(var.azs, count.index)) }, var.tags)
 }

--- a/vpc/public.tf
+++ b/vpc/public.tf
@@ -1,0 +1,26 @@
+resource "aws_subnet" "public" {
+  count = length(var.public_subnets)
+
+  vpc_id                          = aws_vpc.this[0].id
+  cidr_block                      = var.public_subnets[count.index]
+  availability_zone               = element(var.azs, count.index)
+  assign_ipv6_address_on_creation = false
+  map_public_ip_on_launch         = false
+  map_customer_owned_ip_on_launch = false
+
+  tags = merge({ "Name" = format("%s-public-%s", var.name, element(var.azs, count.index)) }, var.tags)
+}
+
+resource "aws_route_table" "public" {
+  count = length(var.public_subnets) > 0 ? 1 : 0
+
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge({ "Name" = format("%s-public", var.name) }, var.tags)
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnets)
+
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public[0].id
+}

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,0 +1,77 @@
+variable "name" {
+  description = "Name to be used on all the resources as identifier"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "azs" {
+  description = "A list of availability zones names or ids in the region"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "cidr" {
+  description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "enable_ipv6" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block."
+  type        = bool
+  default     = false
+}
+
+variable "instance_tenancy" {
+  description = "A tenancy option for instances launched into the VPC"
+  type        = string
+  default     = "default"
+}
+
+variable "public_subnets" {
+  description = "A list of public subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnets" {
+  description = "A list of private subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "intra_subnets" {
+  description = "A list of intra subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_nat_gateway" {
+  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
+  type        = bool
+  default     = false
+}
+
+variable "single_nat_gateway" {
+  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  type        = bool
+  default     = false
+}

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -1,0 +1,19 @@
+resource "aws_vpc" "this" {
+  cidr_block                       = var.cidr
+  instance_tenancy                 = var.instance_tenancy
+  enable_dns_hostnames             = var.enable_dns_hostnames
+  enable_dns_support               = var.enable_dns_support
+  assign_generated_ipv6_cidr_block = var.enable_ipv6
+  enable_classiclink               = false
+  enable_classiclink_dns_support   = false
+  tags                             = var.tags
+
+  count = 1
+}
+
+resource "aws_default_security_group" "this" {
+  vpc_id = aws_vpc.this[count.index].id
+  tags   = merge({ "Name" = "default" }, var.tags)
+
+  count = 1
+}

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -1,4 +1,7 @@
 resource "aws_vpc" "this" {
+  count = 1
+
+  #bridgecrew:skip=BC_AWS_LOGGING_9:VPC Flow Logs are expensive and can be added with an additional Nullstone block
   cidr_block                       = var.cidr
   instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames
@@ -7,13 +10,11 @@ resource "aws_vpc" "this" {
   enable_classiclink               = false
   enable_classiclink_dns_support   = false
   tags                             = var.tags
-
-  count = 1
 }
 
 resource "aws_default_security_group" "this" {
+  count = 1
+
   vpc_id = aws_vpc.this[count.index].id
   tags   = merge({ "Name" = "default" }, var.tags)
-
-  count = 1
 }


### PR DESCRIPTION
This PR adds compliance badges and fixes compliance.

Since the underlying module (official Hashi module) violated several compliance policies, I had to pull in the necessary parts from that module and make necessary adjustments.
The module was greatly simplified and may cause faster plan times.

Also, the bridgecrew scan is manually run before publishing the module to Nullstone which will update the badges in the README.