### PR TITLE
Ensure the network works cleanly with Kubernetes

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,2 +1,6 @@
-provider "aws" {}
+provider "aws" {
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
+}
 data "aws_availability_zones" "this" {}


### PR DESCRIPTION
Preventing kubernetes tag removals from resources -- this prevents the network from removing tags that the kubernetes module adds.